### PR TITLE
11-add-detailed-command-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `--detailed` option to show failed/pass rules for each URLs ([#11](https://github.com/lightship-core/lightship-laravel/issues/11)).
+
 ### Fixed
 
 - No more warning about `tests/Feature/Commands/LightshipRunTest.php` not complying with PSR-4 autoloading standard ([#10](https://github.com/lightship-core/lightship-laravel/issues/10)).
+
+### Breaked
+
+- `lightship:run` will not display failed/passed rules for each URLs by default ([#11](https://github.com/lightship-core/lightship-laravel/issues/11)).
 
 ## [0.3.1] 2022-05-05
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ composer require --dev lightship-core/lightship-laravel
 
 - [Using the facade](#using-the-facade)
 - [Using the comand](#using-the-comand)
+- [Show failed/passed rules when using the command](#show-failedpassed-rules-when-using-the-command)
 
 ### Using the facade
 
@@ -106,6 +107,27 @@ class MyCommand extends Command
     ]);
   }
 }
+```
+
+### Show failed/passed rules when using the command
+
+By default, the command does not show the failed/passed rules of each URLs to save some space. If you want to show the detail, use the `--detailed` option.
+
+```bash
+php artisan lightship:run --route home.index --detailed
+```
+
+Or by calling `Artisan::call`:
+
+```php
+use Illuminate\Support\Facades\Artisan;
+
+// ...
+
+Artisan::call("lightship:run", [
+  "--route" => "home.index",
+  "--detailed" => true,
+]);
 ```
 
 ## Tests

--- a/src/Commands/LightshipRun.php
+++ b/src/Commands/LightshipRun.php
@@ -13,7 +13,7 @@ use Lightship\RuleType;
 
 class LightshipRun extends Command
 {
-    protected $signature = 'lightship:run {--r|route=* : The route to scan.} {--u|url=* : The URL to scan.}';
+    protected $signature = 'lightship:run {--r|route=* : The route to scan.} {--u|url=* : The URL to scan.} {--d|detailed : Shows the rules that passed/failed.}';
 
     /**
      * The console command description.
@@ -89,7 +89,10 @@ class LightshipRun extends Command
         ];
 
         $lines = static::addScoreLines($route, $report, $lines);
-        $lines = static::addResultLines($route, $report, $lines);
+
+        if ($this->option("detailed")) {
+            $lines = static::addResultLines($route, $report, $lines);
+        }
 
         $this->stackSummary($report);
 

--- a/tests/Feature/Commands/LightshipRunTest.php
+++ b/tests/Feature/Commands/LightshipRunTest.php
@@ -30,6 +30,7 @@ final class LightshipRunTest extends TestCase
 
         $command = $this->artisan("lightship:run", [
             "--url" => $url,
+            "--detailed" => true,
         ]);
 
         assert($command instanceof PendingCommand);
@@ -64,6 +65,58 @@ final class LightshipRunTest extends TestCase
             ->expectsOutput("    ❌ langPresent")
             ->expectsOutput("    ❌ linksDefineHref")
             ->expectsOutput("    ❌ metaDescriptionPresent")
+            ->expectsOutput("Passed   0")
+            ->expectsOutput("Failed   1")
+            ->expectsOutput("Total    1");
+    }
+
+    public function testOnlyShowsUrlAndScoresWhenDetailedOptionIsNotUsed(): void
+    {
+        $client = new Client([
+            "handler" => HandlerStack::create(new MockHandler([
+                new Response(200, [], "")
+            ]))
+        ]);
+
+        Lightship::client($client);
+
+        $url = $this->faker->url();
+
+        $command = $this->artisan("lightship:run", [
+            "--url" => $url,
+        ]);
+
+        assert($command instanceof PendingCommand);
+
+        $command->assertSuccessful()
+            ->expectsOutputToContain($url)
+            ->expectsOutputToContain("  accessibility  44")
+            ->expectsOutputToContain("  performance    50")
+            ->expectsOutputToContain("  security       50")
+            ->expectsOutputToContain("  seo             0")
+            ->doesntExpectOutput("  accessibility")
+            ->doesntExpectOutput("    ❌ metaViewportPresent")
+            ->doesntExpectOutput("    ❌ useLandmarkTags")
+            ->doesntExpectOutput("    ✔️  buttonsAndLinksUseAccessibleName")
+            ->doesntExpectOutput("    ✔️  idsAreUnique")
+            ->doesntExpectOutput("    ✔️  imagesHaveAltAttributes")
+            ->doesntExpectOutput("    ❌ doctypeHtmlPresent")
+            ->doesntExpectOutput("    ❌ metaThemeColorPresent")
+            ->doesntExpectOutput("  performance  ")
+            ->doesntExpectOutput("    ❌ textCompressionEnabled")
+            ->doesntExpectOutput("    ✔️  noRedirects")
+            ->doesntExpectOutput("    ✔️  fastResponseTime")
+            ->doesntExpectOutput("    ❌ usesHttp2")
+            ->doesntExpectOutput("  security     ")
+            ->doesntExpectOutput("    ❌ xFrameOptionsPresent")
+            ->doesntExpectOutput("    ❌ strictTransportSecurityHeaderPresent")
+            ->doesntExpectOutput("    ✔️  serverHeaderHidden")
+            ->doesntExpectOutput("    ✔️  xPoweredByHidden")
+            ->doesntExpectOutput("  seo          ")
+            ->doesntExpectOutput("    ❌ titlePresent")
+            ->doesntExpectOutput("    ❌ langPresent")
+            ->doesntExpectOutput("    ❌ linksDefineHref")
+            ->doesntExpectOutput("    ❌ metaDescriptionPresent")
             ->expectsOutput("Passed   0")
             ->expectsOutput("Failed   1")
             ->expectsOutput("Total    1");


### PR DESCRIPTION
## Added

- New `--detailed` option to the command to show failed/passed rules

## Fixed

N/A

## Breaked

- `lightship:run` does not shows failed/passed rules by default