### PR TITLE
18-use-composer-audit-instead-of-symfony-security-checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install
         run: docker-compose run --rm composer install
 
-      - name: Install security checker
-        run: docker-compose run --rm composer run install-security-checker
-
       - name: Analyse
         run: docker-compose run --rm composer run analyse
 
@@ -60,9 +57,6 @@ jobs:
 
       - name: Install
         run: docker-compose run --rm composer81 install
-
-      - name: Install security checker
-        run: docker-compose run --rm composer81 run install-security-checker
 
       - name: Analyse
         run: docker-compose run --rm composer81 run analyse

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Artisan::call("lightship:run", [
 ```
 composer check-platform-reqs
 composer install
-composer run install-security-checker
 composer run analyse
 composer run test
 composer run lint

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "test": "testbench package:test --coverage",
         "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
         "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer --using-cache=no --allow-risky=yes fix",
-        "install-security-checker": "local-php-security-checker-installer",
         "security-check": "composer audit --locked --no-dev",
         "update-check": "composer outdated --strict --direct"
     },


### PR DESCRIPTION
## Added 

- Use `composer audit` instead of symfony security checker

## Fixed

N/A

## Breaking

N/A