### PR TITLE
24-fix-php-stan-missin-xdebug-flag-warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "1.9.11"
     },
     "scripts": {
-        "analyse": "phpstan analyse",
+        "analyse": "phpstan analyse --xdebug",
         "test": "testbench package:test --coverage",
         "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
         "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer --using-cache=no --allow-risky=yes fix",


### PR DESCRIPTION
## Added

N/A

## Fixed

- Missing xdebug flag when calling PHPStan

## Breaking

N/A